### PR TITLE
Set content language to current locale for guests

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -333,7 +333,9 @@ after_initialize do
     if Multilingual::ContentLanguage.topic_filtering_enabled
       content_languages = query.user ?
                           query.user.content_languages :
-                          [*query.options[:content_languages]]
+                          query.options[:content_languages] ?
+                          [*query.options[:content_languages]] :
+                          [I18n.locale.to_s]
 
       if content_languages.present? && content_languages.any?
         result = result.joins(:tags).where("tags.name in (?)", content_languages)


### PR DESCRIPTION
If `set locale from accept language header` is enabled, the locale will be set based on the `Accept-Languages` HTTP header, and the content language will also be set to the same value. One issue is that, if the user changes the locale by clicking on the language switcher (not the content language switcher, which doesn't do anything for guests even in the upstream version), the content language will also be updated to match, which means that these two settings are inseparably linked. This shouldn't be a big deal because most users are going to want to see posts in the same language as the interface, but ideally these two things should be separate. Users who are logged in are not affected.
