### PR TITLE
Fix email digest filtering

### DIFF
--- a/extensions/topic.rb
+++ b/extensions/topic.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module MultilingualTranslatorTopicExtension
-  def self.for_digest(user, since, opts = nil)
+  def for_digest(user, since, opts = nil)
     topics = super(user, since, opts)
 
     if Multilingual::ContentLanguage.topic_filtering_enabled

--- a/plugin.rb
+++ b/plugin.rb
@@ -76,7 +76,7 @@ after_initialize do
   ::DiscourseTagging.singleton_class.prepend DiscourseTaggingMultilingualExtension
   ::CategoryList.prepend CategoryListMultilingualExtension
   ::Post.prepend MultilingualTranslatorPostExtension
-  ::Topic.prepend MultilingualTranslatorTopicExtension
+  ::Topic.singleton_class.prepend MultilingualTranslatorTopicExtension
   ::ApplicationController.prepend ApplicationControllerMultilingualExtension
 
   register_html_builder('server:before-script-load') do |ctx|


### PR DESCRIPTION
MultilingualTranslatorTopicExtension wasn't being added correctly, so its for_digest() was never run.