### PR TITLE
Rename NotifyMailingListSubscriberMultilingualsExtension

### DIFF
--- a/extensions/notify_mailing_list_subscribers.rb
+++ b/extensions/notify_mailing_list_subscribers.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-module NotifyMailingListSubscriberMultilingualsExtension
+module NotifyMailingListSubscriberMultilingualExtension
   # This is largely taken from ::Jobs::NotifyMailingListSubscribers in Discourse
   def execute(args)
     return if SiteSetting.disable_mailing_list_mode

--- a/plugin.rb
+++ b/plugin.rb
@@ -79,7 +79,7 @@ after_initialize do
   ::Post.prepend MultilingualTranslatorPostExtension
   ::Topic.singleton_class.prepend MultilingualTranslatorTopicExtension
   ::ApplicationController.prepend ApplicationControllerMultilingualExtension
-  ::Jobs::NotifyMailingListSubscribers.prepend NotifyMailingListSubscriberMultilingualsExtension
+  ::Jobs::NotifyMailingListSubscribers.prepend NotifyMailingListSubscriberMultilingualExtension
 
   register_html_builder('server:before-script-load') do |ctx|
     loader = Multilingual::LocaleLoader.new(ctx)


### PR DESCRIPTION
Change the name to NotifyMailingListSubscriberMultilingualExtension so that it's more consistent with how other modules are named.