### PR TITLE
Implement a workaround for duplicate digest entries

### DIFF
--- a/extensions/topic.rb
+++ b/extensions/topic.rb
@@ -16,6 +16,11 @@ module MultilingualTranslatorTopicExtension
       end
     end
 
+    # Work around a bug in Discourse that causes duplicate topics to appear in
+    # digests.
+    topics = Topic.where(id: topics.limit(nil).select(:id)).distinct
+    topics = topics.limit(opts[:limit]) if opts and opts[:limit]
+
     topics
   end
 end


### PR DESCRIPTION
As of 2024-09-20, there is [a bug](https://meta.discourse.org/t/multiple-repeated-summary-mail-entries/296539) in Discourse that causes digest emails to sometimes contain duplicate entries. This workaround adjusts the SQL query used to find digest entries to remove these duplicates.