### PR TITLE
Revert "Implement a workaround for duplicate digest entries"

### DIFF
--- a/extensions/topic.rb
+++ b/extensions/topic.rb
@@ -16,11 +16,6 @@ module MultilingualTranslatorTopicExtension
       end
     end
 
-    # Work around a bug in Discourse that causes duplicate topics to appear in
-    # digests.
-    topics = Topic.where(id: topics.limit(nil).select(:id)).distinct
-    topics = topics.limit(opts[:limit]) if opts and opts[:limit]
-
     topics
   end
 end


### PR DESCRIPTION
This reverts commit a981404e53cc58b508a7f1d515a3b5d4d396bcd6.

The bug that caused the issue has been fixed upstream. See https://github.com/discourse/discourse/pull/29517